### PR TITLE
Fix attribute error with new version of gym.

### DIFF
--- a/mjrl/samplers/base_sampler.py
+++ b/mjrl/samplers/base_sampler.py
@@ -27,7 +27,11 @@ def do_rollout(N,
     if env_name is None and env is None:
         print("No environment specified! Error will be raised")
     if env is None: env = get_environment(env_name)
-    if pegasus_seed is not None: env.env._seed(pegasus_seed)
+    if pegasus_seed is not None: 
+        try:
+            env.env._seed(pegasus_seed)
+        except AttributeError as e:
+            env.env.seed(pegasus_seed)
     T = min(T, env.horizon) 
 
     #print("####### Worker started #######")
@@ -39,7 +43,10 @@ def do_rollout(N,
         # Set pegasus seed if asked
         if pegasus_seed is not None:
             seed = pegasus_seed + ep
-            env.env._seed(seed)
+            try:
+                env.env._seed(seed)
+            except AttributeError as e:
+                env.env.seed(seed)
             np.random.seed(seed)
         else:
             np.random.seed()


### PR DESCRIPTION
When I run `python3 examples/linear_nn_comparison.py` I get an attribute error:
```
Traceback (most recent call last):
  File "examples/linear_nn_comparison.py", line 32, in <module>
    evaluation_rollouts=5)
  File ".../mjrl/mjrl/utils/train_agent.py", line 49, in train_agent
    stats = agent.train_step(**args)
  File ".../mjrl/mjrl/algos/batch_reinforce.py", line 76, in train_step
    self.seed, num_cpu)
  File ".../mjrl/mjrl/samplers/trajectory_sampler.py", line 33, in sample_paths_parallel
    return base_sampler.do_rollout(N, policy, T, None, env_name, pegasus_seed)
  File "...mjrl/mjrl/samplers/base_sampler.py", line 30, in do_rollout
    if pegasus_seed is not None: env.env._seed(pegasus_seed)
AttributeError: 'TimeLimit' object has no attribute '_seed'
```

This commit adds a safety check so that the code is backwards compatible.