### PR TITLE
Adding dtype to the boxes to avoid warning messages from gym

### DIFF
--- a/mjrl/envs/mujoco_env.py
+++ b/mjrl/envs/mujoco_env.py
@@ -49,11 +49,11 @@ class MujocoEnv(gym.Env):
         bounds = self.model.actuator_ctrlrange.copy()
         low = bounds[:, 0]
         high = bounds[:, 1]
-        self.action_space = spaces.Box(low, high)
+        self.action_space = spaces.Box(low, high, dtype=np.float32)
 
         high = np.inf*np.ones(self.obs_dim)
         low = -high
-        self.observation_space = spaces.Box(low, high)
+        self.observation_space = spaces.Box(low, high, dtype=np.float32)
 
         self.seed()
 


### PR DESCRIPTION
This takes care of the warning about missing dtype