### PR TITLE
Replacing `multiprocessing.Pool` with `concurrent.futures.ProcessPoolExecutor`

### DIFF
--- a/mjrl/samplers/core.py
+++ b/mjrl/samplers/core.py
@@ -19,6 +19,8 @@ def do_rollout(
         horizon = 1e6,
         base_seed = None,
         env_kwargs=None,
+        *args,
+        **kwargs,
 ):
     """
     :param num_traj:    number of trajectories (int)
@@ -109,6 +111,8 @@ def sample_paths(
         max_timeouts=4,
         suppress_print=False,
         env_kwargs=None,
+        *args,
+        **kwargs,
         ):
 
     num_cpu = 1 if num_cpu is None else num_cpu
@@ -160,6 +164,8 @@ def sample_data_batch(
         num_cpu = 1,
         paths_per_call = 1,
         env_kwargs=None,
+        *args,
+        **kwargs,
         ):
 
     num_cpu = 1 if num_cpu is None else num_cpu
@@ -200,12 +206,17 @@ def _try_multiprocess(func, input_dict_list, num_cpu, max_process_time, max_time
                 results = [f.result() for f in submit_futures]
             except TimeoutError as e:
                 print(str(e))
-                print("Timeout Error raised...") 
+                print("Timeout Error raised...")
+                print("Trying again..........")
+                return _try_multiprocess(func, input_dict_list, num_cpu, max_process_time, max_timeouts-1)
             except concurrent.futures.CancelledError as e:
                 print(str(e))
                 print("Future Cancelled Error raised...") 
+                print("Trying again..........")
+                return _try_multiprocess(func, input_dict_list, num_cpu, max_process_time, max_timeouts-1)
             except Exception as e:
                 print(str(e))
-                print("Error raised...") 
+                print("Error raised...")
+                print("Run aborted. Error looks complicated, requires debugging.")
                 raise e
     return results

--- a/mjrl/samplers/core.py
+++ b/mjrl/samplers/core.py
@@ -126,7 +126,7 @@ def sample_paths(
     paths_per_cpu = int(np.ceil(num_traj/num_cpu))
     input_dict_list= []
     for i in range(num_cpu):
-        input_dict = dict(num_traj=paths_per_cpu, env=env.env_id, policy=policy,
+        input_dict = dict(num_traj=paths_per_cpu, env=env, policy=policy,
                           eval_mode=eval_mode, horizon=horizon,
                           base_seed=base_seed + i * paths_per_cpu,
                           env_kwargs=env_kwargs)
@@ -135,8 +135,6 @@ def sample_paths(
         start_time = timer.time()
         print("####### Gathering Samples #######")
 
-    print("Input Dict List %s" % (str(input_dict_list)))
-    
     results = _try_multiprocess(do_rollout, input_dict_list,
                                 num_cpu, max_process_time, max_timeouts)
     paths = []

--- a/mjrl/samplers/core.py
+++ b/mjrl/samplers/core.py
@@ -139,9 +139,10 @@ def sample_paths(
                                 num_cpu, max_process_time, max_timeouts)
     paths = []
     # result is a paths type and results is list of paths
-    for result in results:
-        for path in result:
-            paths.append(path)  
+    if results:
+        for result in results:
+            for path in result:
+                paths.append(path)  
 
     if suppress_print is False:
         print("======= Samples Gathered  ======= | >>>> Time taken = %f " %(timer.time()-start_time) )
@@ -196,8 +197,15 @@ def _try_multiprocess(func, input_dict_list, num_cpu, max_process_time, max_time
         with concurrent.futures.ProcessPoolExecutor(max_workers=num_cpu) as executor:
             submit_futures = [executor.submit(func, **input_dict) for input_dict in input_dict_list]
             try:
-                results = [f.result(timeout=max_process_time) for f in submit_futures]
-            except Exception as e:
+                results = [f.result() for f in submit_futures]
+            except TimeoutError as e:
                 print(str(e))
                 print("Timeout Error raised...") 
+            except concurrent.futures.CancelledError as e:
+                print(str(e))
+                print("Future Cancelled Error raised...") 
+            except Exception as e:
+                print(str(e))
+                print("Error raised...") 
+                raise e
     return results

--- a/mjrl/samplers/core.py
+++ b/mjrl/samplers/core.py
@@ -126,7 +126,7 @@ def sample_paths(
     paths_per_cpu = int(np.ceil(num_traj/num_cpu))
     input_dict_list= []
     for i in range(num_cpu):
-        input_dict = dict(num_traj=paths_per_cpu, env=env, policy=policy,
+        input_dict = dict(num_traj=paths_per_cpu, env=env.env_id, policy=policy,
                           eval_mode=eval_mode, horizon=horizon,
                           base_seed=base_seed + i * paths_per_cpu,
                           env_kwargs=env_kwargs)
@@ -135,6 +135,8 @@ def sample_paths(
         start_time = timer.time()
         print("####### Gathering Samples #######")
 
+    print("Input Dict List %s" % (str(input_dict_list)))
+    
     results = _try_multiprocess(do_rollout, input_dict_list,
                                 num_cpu, max_process_time, max_timeouts)
     paths = []

--- a/mjrl/utils/plot_from_logs.py
+++ b/mjrl/utils/plot_from_logs.py
@@ -37,7 +37,7 @@ nrow = int(np.ceil(nplt/ncol))
 xkey = args.xkey
 start_idx = 2
 end_idx = max([len(data[k]) for k in data.keys()])
-xdata = np.arange(end_idx) if xkey is None else \
+xdata = np.arange(end_idx) if xkey is None or xkey == 'None' else \
         [np.sum(data[xkey][:i+1]) * xscale for i in range(len(data[xkey]))]
 
 # make the plot

--- a/mjrl/utils/train_agent.py
+++ b/mjrl/utils/train_agent.py
@@ -114,6 +114,11 @@ def train_agent(job_name, agent,
             mean_pol_perf = np.mean([np.sum(path['rewards']) for path in eval_paths])
             if agent.save_logs:
                 agent.logger.log_kv('eval_score', mean_pol_perf)
+                try:
+                    eval_success = e.env.env.evaluate_success(eval_paths)
+                    agent.logger.log_kv('eval_success', eval_success)
+                except:
+                    pass
 
         if i % save_freq == 0 and i > 0:
             if agent.save_logs:

--- a/projects/model_based_npg/README.md
+++ b/projects/model_based_npg/README.md
@@ -15,7 +15,7 @@ CUDA_VISIBLE_DEVICES=0 python run_model_based_npg.py --output Hopper-v3-pal-exam
 
 - The job directory (`Hopper-v3-pal-example` in the above case) will contain experiment logs as well as periodic saving of learned policies. The experiment results can be quickly explored by using a plotting script included with `mjrl`.
 ```
-python ../../mjrl/utils/explore_results.py --output Hopper-v3-pal-example/plot.png --data Hopper-v3-pal-example/logs/log.pickle --xkey num_samples
+python ../../mjrl/utils/plot_from_logs.py --output Hopper-v3-pal-example/plot.png --data Hopper-v3-pal-example/logs/log.pickle --xkey num_samples
 ```
 
 - An example of the above produces the following plot. The x axis is the number of samples environment interactions (samples). Look for the train_score and eval_score plots which are the performances of the Gaussian policy and the mean of the Gaussian policy respectively. As we can see, the PAL setting of model-based NPG leads to highly sample efficient learning of a successful policy. 

--- a/projects/morel/README.md
+++ b/projects/morel/README.md
@@ -29,7 +29,7 @@ CUDA_VISIBLE_DEVICES=0 python run_morel.py --config configs/d4rl_hopper_medium.t
 
 - The job directory (`hopper-medium-v0-example` in the above example) will contain experiment logs as well as periodic saving of learned policies. The experiment results can be quickly explored by using a plotting script included with `mjrl`.
 ```
-python ../../mjrl/utils/explore_results.py --output hopper-medium-v0-example/plot.png --data hopper-medium-v0-example/logs/log.pickle
+python ../../mjrl/utils/plot_from_logs.py --output hopper-medium-v0-example/plot.png --data hopper-medium-v0-example/logs/log.pickle
 ```
 
 - An example of the resulting plot is below. In the plot, `train_score` refers to the policy performance in the pessimistic MDP and `eval_score` refers to the value in the environment (unknown underlying MDP).


### PR DESCRIPTION
Replacing `multiprocessing.Pool` with `concurrent.futures.ProcessPoolExecutor`. Latter seem much more stable and bug free and causes no lock ups.

## TEST PLAN

`python hydra_mjrl_launcher.py --multirun hydra/launcher=local hydra/output=local`