### PR TITLE
add outputdic for player specific color spaces

### DIFF
--- a/mjrl/envs/mujoco_env.py
+++ b/mjrl/envs/mujoco_env.py
@@ -170,7 +170,8 @@ class MujocoEnv(gym.Env):
                                    mode='exploration',
                                    save_loc='/tmp/',
                                    filename='newvid',
-                                   camera_name=None):
+                                   camera_name=None,
+                                   outputdict=None):
         import skvideo.io
         for ep in range(num_episodes):
             print("Episode %d: rendering offline " % ep, end='', flush=True)
@@ -188,7 +189,7 @@ class MujocoEnv(gym.Env):
                 arrs.append(curr_frame[::-1,:,:])
                 print(t, end=', ', flush=True)
             file_name = save_loc + filename + str(ep) + ".mp4"
-            skvideo.io.vwrite( file_name, np.asarray(arrs))
+            skvideo.io.vwrite( file_name, np.asarray(arrs),outputdict)
             print("saved", file_name)
             t1 = timer.time()
             print("time taken = %f"% (t1-t0))


### PR DESCRIPTION
`outputdic` needs to be set to `{"-pix_fmt": "yuv420p"}` for movie clips to work with quicktime and other players
https://trac.ffmpeg.org/wiki/Encode/H.264#Encodingfordumbplayers